### PR TITLE
Automatically build the containers that Concourse needs.

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -50,6 +50,12 @@ resources:
           only_mergeable: true
           require_review_approval: true
 
+    - name: nmckinley-pr
+      type: docker-image
+      source:
+        repository: nmckinley/concourse-github-pr-resource
+        username: nmckinley
+        password: ((dockerhub_password))
 jobs:
     - name: mm-generate
       plan:
@@ -148,5 +154,11 @@ jobs:
                     method: squash
                     commit_msg: mm-output/commit_message
 
+    - name: create-pr-image
+      plan:
+          - get: ci
+          - put: nmckinley-pr
+            params:
+              build: ci/containers/pull-request
+
 # TODO(@ndmckinley): System for confirming no downstream conflicts.
-# TODO(@ndmckinley): System for building the Docker containers this depends on.

--- a/containers/pull-request/Dockerfile
+++ b/containers/pull-request/Dockerfile
@@ -1,0 +1,4 @@
+FROM jtarchie/pr:latest
+ADD patchfile /patchfile
+WORKDIR /opt/resource
+RUN patch -p2 < /patchfile

--- a/containers/pull-request/patchfile
+++ b/containers/pull-request/patchfile
@@ -1,0 +1,45 @@
+diff --git a/assets/lib/filters/dependent_prs.rb b/assets/lib/filters/dependent_prs.rb
+new file mode 100644
+index 0000000..e50d45b
+--- /dev/null
++++ b/assets/lib/filters/dependent_prs.rb
+@@ -0,0 +1,16 @@
++module Filters
++  class Dependents 
++    def initialize(pull_requests:, input: Input.instance)
++      @pull_requests = pull_requests
++      @input = input
++    end
++
++    def pull_requests
++      if @input.source.check_dependent_prs
++        @memoized ||= @pull_requests.delete_if {|x| !x.dependent_prs_merged? }
++      else
++        @pull_requests
++      end
++    end
++  end
++end
+diff --git a/assets/lib/pull_request.rb b/assets/lib/pull_request.rb
+index 8252408..d0c1762 100644
+--- a/assets/lib/pull_request.rb
++++ b/assets/lib/pull_request.rb
+@@ -29,6 +29,18 @@ class PullRequest
+     %w[OWNER COLLABORATOR MEMBER].include? @pr['author_association']
+   end
+ 
++  def dependent_prs_merged?
++    # For all comments on the pull request...
++    Octokit.pull_comments(base_repo, id).all? do |c|
++      # If they're by someone we trust...
++      return true unless %w(OWNER COLLABORATOR MEMBER).include?(c['author_association'])
++      # Confirm that any PR they reference as a dependency is merged.
++      c['body'].scan(/depends: https:\/\/github.com\/(?<user>\w*)\/(?<repo>[\w-]*)\/pull\/(?<pr>\d*)/).all? {
++        |m| Octokit.pull_request(m[0] + "/" + m[1], m[2])['merged']
++      }
++    end
++  end
++
+   def equals?(id:, sha:)
+     [self.sha, self.id.to_s] == [sha, id.to_s]
+   end


### PR DESCRIPTION
It's easy to automate container creation in Concourse - might as well get this pending PR built in automatically instead of doing it by hand from time to time as the upstream moves.